### PR TITLE
Adds military bases to state address table.

### DIFF
--- a/lib/indirizzo/constants.rb
+++ b/lib/indirizzo/constants.rb
@@ -587,6 +587,12 @@ module Indirizzo
   # The State constant maps US state and territory names to their 2-letter
   # USPS abbreviations.
   State = Map[
+    "Armed Forces Americas"           => "AA",
+    "Armed Forces Africa"             => "AE",
+    "Armed Forces Canada"             => "AE",
+    "Armed Forces Europe"             => "AE",
+    "Armed Forces Middle East"        => "AE",
+    "Armed Forces Pacific"            => "AP",
     "Alabama"		=> "AL",
     "Alaska"		=> "AK",
     "American Samoa"	=> "AS",


### PR DESCRIPTION
Needed additional entries for military base short code state addresses. These are recognized by the post office and will make address table more complete.